### PR TITLE
MathKeyboard component enhance perf

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "jest": "^24.9.0",
     "metro-react-native-babel-preset": "^0.58.0",
     "react-test-renderer": "16.11.0",
-    "typescript": "^3.9.2"
+    "typescript": "^3.9.3"
   },
   "jest": {
     "preset": "react-native"


### PR DESCRIPTION
Refactored to use `FlatList`
It seems that it re-renders the keyboards every time I press a button (that displays a keyboard) which is expensive. I suggest you solve this.
Perhaps by joining all keyboards into one.... There's a few ways to handle this.
But it is not purely a problem of the library. Sure, it's expensive to render math, but this is minor if you handle the unnecessary renders.
Once you manage to render all keyboards just once and then just display them again and again this issue will seize to exist.